### PR TITLE
Comment out fetch pidfile

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -16,7 +16,7 @@ port        ENV.fetch("PORT") { 3000 }
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+# pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together


### PR DESCRIPTION
To solve crashed heroku app.

2020-10-05T02:57:36.267787+00:00 heroku[web.1]: Starting process with command `bundle exec puma -C config/puma.rb`
2020-10-05T02:57:39.078664+00:00 heroku[worker.1]: Process exited with status 1
2020-10-05T02:57:39.126061+00:00 heroku[worker.1]: State changed from up to crashed
2020-10-05T02:57:40.396281+00:00 app[web.1]: [4] Puma starting in cluster mode...
2020-10-05T02:57:40.396447+00:00 app[web.1]: [4] * Version 3.12.6 (ruby 2.4.0-p0), codename: Llamas in Pajamas
2020-10-05T02:57:40.396533+00:00 app[web.1]: [4] * Min threads: 5, max threads: 5
2020-10-05T02:57:40.396645+00:00 app[web.1]: [4] * Environment: production
2020-10-05T02:57:40.396716+00:00 app[web.1]: [4] * Process workers: 2
2020-10-05T02:57:40.396835+00:00 app[web.1]: [4] * Phased restart available
2020-10-05T02:57:40.397415+00:00 app[web.1]: [4] * Listening on tcp://0.0.0.0:58452
2020-10-05T02:57:40.397690+00:00 app[web.1]: [4] Use Ctrl-C to stop
2020-10-05T02:57:40.398344+00:00 app[web.1]: bundler: failed to load command: puma (/app/vendor/bundle/ruby/2.4.0/bin/puma)
2020-10-05T02:57:40.398444+00:00 app[web.1]: Errno::ENOENT: No such file or directory @ rb_sysopen - tmp/pids/server.pid
2020-10-05T02:57:40.398464+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/puma-3.12.6/lib/puma/launcher.rb:133:in `initialize'
2020-10-05T02:57:40.398465+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/puma-3.12.6/lib/puma/launcher.rb:133:in `open'
2020-10-05T02:57:40.398465+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/puma-3.12.6/lib/puma/launcher.rb:133:in `write_pid'
2020-10-05T02:57:40.398466+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/puma-3.12.6/lib/puma/launcher.rb:106:in `write_state'
2020-10-05T02:57:40.398466+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/puma-3.12.6/lib/puma/cluster.rb:460:in `run'
2020-10-05T02:57:40.398467+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/puma-3.12.6/lib/puma/launcher.rb:186:in `run'
2020-10-05T02:57:40.398467+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/puma-3.12.6/lib/puma/cli.rb:80:in `run'
2020-10-05T02:57:40.398467+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/gems/puma-3.12.6/bin/puma:10:in `<top (required)>'
2020-10-05T02:57:40.398468+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/bin/puma:22:in `load'
2020-10-05T02:57:40.398498+00:00 app[web.1]: /app/vendor/bundle/ruby/2.4.0/bin/puma:22:in `<top (required)>'
2020-10-05T02:57:40.489892+00:00 heroku[web.1]: Process exited with status 1
2020-10-05T02:57:40.587763+00:00 heroku[web.1]: State changed from starting to crashed
